### PR TITLE
Modify SlidingWindowExtractor output sequence

### DIFF
--- a/src/SlidingWindowExtractor.py
+++ b/src/SlidingWindowExtractor.py
@@ -26,7 +26,6 @@ class SlidingWindowExtractor:
         input_seq = []
         input_quality = np.zeros((rows, self.input_length))
         output_seq = []
-        output_quality = np.zeros((rows, self.output_length))
 
         curr_row = 0
 
@@ -44,9 +43,8 @@ class SlidingWindowExtractor:
                 output_offset = i + self.input_length + self.spacing
                 for j in range(self.output_length):
                     output_seq_vector.append(sequence[output_offset + j])
-                    output_quality[curr_row][j] = quality[output_offset + j]
                 input_seq.append(input_seq_vector)
-                output_seq.append(output_seq_vector)
+                output_seq.append(input_seq_vector + output_seq_vector)
                 curr_row += 1
 
-        return input_seq, input_quality, output_seq, output_quality
+        return input_seq, input_quality, output_seq

--- a/test/test_sliding_window_extractor.py
+++ b/test/test_sliding_window_extractor.py
@@ -45,14 +45,12 @@ class TestSlidingWindowExtractor(TestCase):
         input_matrix = input_output[0]
         input_quality_matrix = input_output[1]
         output_matrix = input_output[2]
-        output_quality_matrix = input_output[3]
 
         self.assertEqual(len(input_matrix), 3)
         self.assertEqual(len(input_matrix[0]), 4)
         self.assertEqual(input_quality_matrix.shape, (3, 4))
         self.assertEqual(len(output_matrix), 3)
-        self.assertEqual(len(output_matrix[0]), 4)
-        self.assertEqual(output_quality_matrix.shape, (3, 4))
+        self.assertEqual(len(output_matrix[0]), 8)
         expected_input = np.array([
             ["A", "A", "T", "T"],
             ["A", "T", "T", "G"],
@@ -64,19 +62,13 @@ class TestSlidingWindowExtractor(TestCase):
             [28, 10, 28, 32]
         ])
         expected_output = np.array([
-            ["G", "A", "G", "T"],
-            ["A", "G", "T", "C"],
-            ["G", "T", "C", "G"]
-        ])
-        expected_output_quality = np.array([
-            [28, 32, 32, 28],
-            [32, 32, 28, 32],
-            [32, 28, 32, 35]
+            ["A", "A", "T", "T", "G", "A", "G", "T"],
+            ["A", "T", "T", "G", "A", "G", "T", "C"],
+            ["T", "T", "G", "A", "G", "T", "C", "G"]
         ])
         np.testing.assert_array_equal(input_matrix, expected_input)
         np.testing.assert_array_equal(input_quality_matrix, expected_input_quality)
         np.testing.assert_array_equal(output_matrix, expected_output)
-        np.testing.assert_array_equal(output_quality_matrix, expected_output_quality)
 
     def test_extract_input_output_from_sequence_minimal_spacing(self):
         extractor = SlidingWindowExtractor(1, 1, 1)
@@ -84,14 +76,12 @@ class TestSlidingWindowExtractor(TestCase):
         input_matrix = input_output[0]
         input_quality_matrix = input_output[1]
         output_matrix = input_output[2]
-        output_quality_matrix = input_output[3]
 
         self.assertEqual(len(input_matrix), 8)
         self.assertEqual(len(input_matrix[0]), 1)
         self.assertEqual(input_quality_matrix.shape, (8, 1))
         self.assertEqual(len(output_matrix), 8)
-        self.assertEqual(len(output_matrix[0]), 1)
-        self.assertEqual(output_quality_matrix.shape, (8, 1))
+        self.assertEqual(len(output_matrix[0]), 2)
         expected_input = np.array([
             ["A"],
             ["A"],
@@ -113,29 +103,18 @@ class TestSlidingWindowExtractor(TestCase):
             [28]
         ])
         expected_output = np.array([
-            ["T"],
-            ["T"],
-            ["G"],
-            ["A"],
-            ["G"],
-            ["T"],
-            ["C"],
-            ["G"]
-        ])
-        expected_output_quality = np.array([
-            [28],
-            [10],
-            [28],
-            [32],
-            [32],
-            [28],
-            [32],
-            [35]
+            ["A", "T"],
+            ["A", "T"],
+            ["T", "G"],
+            ["T", "A"],
+            ["G", "G"],
+            ["A", "T"],
+            ["G", "C"],
+            ["T", "G"]
         ])
         np.testing.assert_array_equal(input_matrix, expected_input)
         np.testing.assert_array_equal(input_quality_matrix, expected_input_quality)
         np.testing.assert_array_equal(output_matrix, expected_output)
-        np.testing.assert_array_equal(output_quality_matrix, expected_output_quality)
 
     def test_extract_input_output_from_sequence(self):
         extractor = SlidingWindowExtractor(4, 3, 2)
@@ -143,14 +122,12 @@ class TestSlidingWindowExtractor(TestCase):
         input_matrix = input_output[0]
         input_quality_matrix = input_output[1]
         output_matrix = input_output[2]
-        output_quality_matrix = input_output[3]
 
         self.assertEqual(len(input_matrix), 2)
         self.assertEqual(len(input_matrix[0]), 4)
         self.assertEqual(input_quality_matrix.shape, (2, 4))
         self.assertEqual(len(output_matrix), 2)
-        self.assertEqual(len(output_matrix[0]), 2)
-        self.assertEqual(output_quality_matrix.shape, (2, 2))
+        self.assertEqual(len(output_matrix[0]), 6)
         expected_input = np.array([
             ["A", "A", "T", "T"],
             ["A", "T", "T", "G"]
@@ -160,17 +137,12 @@ class TestSlidingWindowExtractor(TestCase):
             [28, 28, 10, 28]
         ])
         expected_output = np.array([
-            ["T", "C"],
-            ["C", "G"]
-        ])
-        expected_output_quality = np.array([
-            [28, 32],
-            [32, 35]
+            ["A", "A", "T", "T", "T", "C"],
+            ["A", "T", "T", "G", "C", "G"]
         ])
         np.testing.assert_array_equal(input_matrix, expected_input)
         np.testing.assert_array_equal(input_quality_matrix, expected_input_quality)
         np.testing.assert_array_equal(output_matrix, expected_output)
-        np.testing.assert_array_equal(output_quality_matrix, expected_output_quality)
 
     def test_extract_input_output_from_sequence_too_much_input(self):
         extractor = SlidingWindowExtractor(11, 1, 1)
@@ -178,12 +150,10 @@ class TestSlidingWindowExtractor(TestCase):
         input_matrix = input_output[0]
         input_quality_matrix = input_output[1]
         output_matrix = input_output[2]
-        output_quality_matrix = input_output[3]
 
         self.assertEqual(len(input_matrix), 0)
         self.assertEqual(len(input_quality_matrix), 0)
         self.assertEqual(len(output_matrix), 0)
-        self.assertEqual(len(output_quality_matrix), 0)
 
     def test_extract_input_output_from_sequence_too_much_spacing(self):
         extractor = SlidingWindowExtractor(1, 11, 1)
@@ -191,12 +161,10 @@ class TestSlidingWindowExtractor(TestCase):
         input_matrix = input_output[0]
         input_quality_matrix = input_output[1]
         output_matrix = input_output[2]
-        output_quality_matrix = input_output[3]
 
         self.assertEqual(len(input_matrix), 0)
         self.assertEqual(len(input_quality_matrix), 0)
         self.assertEqual(len(output_matrix), 0)
-        self.assertEqual(len(output_quality_matrix), 0)
 
     def test_extract_input_output_from_sequence_too_much_output(self):
         extractor = SlidingWindowExtractor(1, 1, 11)
@@ -204,9 +172,7 @@ class TestSlidingWindowExtractor(TestCase):
         input_matrix = input_output[0]
         input_quality_matrix = input_output[1]
         output_matrix = input_output[2]
-        output_quality_matrix = input_output[3]
 
         self.assertEqual(len(input_matrix), 0)
         self.assertEqual(len(input_quality_matrix), 0)
         self.assertEqual(len(output_matrix), 0)
-        self.assertEqual(len(output_quality_matrix), 0)


### PR DESCRIPTION
1) Removed the output_quality because I don't think we
ever care about the quality in the output
2) The output sequence now includes the input sequence
since we're doing an auto-encoding, this is an easily
revertible commit if we need to