### PR TITLE
Allow choice of a start index for sequence matching

### DIFF
--- a/src/SequenceMatchCalculator.py
+++ b/src/SequenceMatchCalculator.py
@@ -2,11 +2,17 @@ class SequenceMatchCalculator:
     def __init__(self):
         pass
 
-    def compare_sequences(self, seq1, seq2):
+    def compare_sequences(self, seq1, seq2, start_idx=0, bases_to_check=None):
         #TODO: assumes equal length
         mismatches = 0
-        for i in range(len(seq1)):
-            if seq1[i] != seq2[i]:
+        length = len(seq1) - max(start_idx, 0)
+
+        if bases_to_check != None:
+            length = min(len(seq1) - start_idx, max(bases_to_check, 0))
+
+        for i in range(length):
+            idx = i + start_idx
+            if seq1[idx] != seq2[idx]:
                 mismatches += 1
         return mismatches
 

--- a/test/test_sequence_match_calculator.py
+++ b/test/test_sequence_match_calculator.py
@@ -25,3 +25,61 @@ class TestSequenceMatchCalculator(TestCase):
             ["A", "G", "G", "A", "A", "T", "C", "C", "G", "A"]
         ))
 
+    def test_compare_different_sequences_from_offset(self):
+        self.assertEqual(7, self.matcher.compare_sequences(
+            ["A", "T", "G", "C", "A", "T", "G", "C", "A", "T"],
+            ["T", "G", "C", "A", "T", "G", "C", "A", "T", "G"],
+            3
+        ))
+
+    def test_compare_different_sequences_from_offset_longer_than_string(self):
+        self.assertEqual(0, self.matcher.compare_sequences(
+            ["A", "T", "G", "C", "A", "T", "G", "C", "A", "T"],
+            ["T", "G", "C", "A", "T", "G", "C", "A", "T", "G"],
+            11
+        ))
+
+    def test_compare_different_sequences_from_negative_offset(self):
+        self.assertEqual(10, self.matcher.compare_sequences(
+            ["A", "T", "G", "C", "A", "T", "G", "C", "A", "T"],
+            ["T", "G", "C", "A", "T", "G", "C", "A", "T", "G"],
+            -2
+        ))
+
+    def test_compare_same_sequences_from_offset(self):
+        self.assertEqual(0, self.matcher.compare_sequences(
+            ["A", "T", "G", "C", "A", "T", "G", "C", "A", "T"],
+            ["A", "T", "G", "C", "A", "T", "G", "C", "A", "T"],
+            3
+        ))
+
+    def test_compare_similar_sequences_from_offset(self):
+        self.assertEqual(4, self.matcher.compare_sequences(
+            ["A", "T", "G", "C", "A", "T", "G", "C", "A", "T"],
+            ["A", "G", "G", "A", "A", "T", "C", "C", "G", "A"],
+            3
+        ))
+
+    def test_compare_similar_sequences_from_offset_check_4_bases(self):
+        self.assertEqual(2, self.matcher.compare_sequences(
+            ["A", "T", "G", "C", "A", "T", "G", "C", "A", "T"],
+            ["A", "G", "G", "A", "A", "T", "C", "C", "G", "A"],
+            3,
+            4
+        ))
+
+    def test_compare_similar_sequences_from_offset_check_20_bases_doesnt_exceed(self):
+        self.assertEqual(4, self.matcher.compare_sequences(
+            ["A", "T", "G", "C", "A", "T", "G", "C", "A", "T"],
+            ["A", "G", "G", "A", "A", "T", "C", "C", "G", "A"],
+            3,
+            20
+        ))
+
+    def test_compare_similar_sequences_from_offset_check_negative_bases_treated_as_0(self):
+        self.assertEqual(0, self.matcher.compare_sequences(
+            ["A", "T", "G", "C", "A", "T", "G", "C", "A", "T"],
+            ["A", "G", "G", "A", "A", "T", "C", "C", "G", "A"],
+            3,
+            -5
+        ))


### PR DESCRIPTION
We can now choose where in the sequence we want to
start

This might be useful if we care about only a specific
substring of a sequence