### PR TITLE
Remove fill in the blanks padding logic

### DIFF
--- a/src/KmerLabelEncoder.py
+++ b/src/KmerLabelEncoder.py
@@ -7,48 +7,45 @@ class KmerLabelEncoder:
     def __init__(self):
         pass
 
-    # TODO: consider removing this parameter once we don't need it (eg. we decide on if we want to pad or not)
     #TODO: consider making shifted output optional
-    def encode_kmers(self, input_kmers, output_kmers, quality_kmers, fill_in_the_blanks=False):
+    def encode_kmers(self, input_kmers, output_kmers, quality_kmers):
         #TODO: handle empty arrays
         ONE_HOT_ENCODING_IDX_MAP = CONSTANTS.INTEGER_ENCODING_MAP
 
         input_kmer_count = len(input_kmers)
-        input_kmer_length = len(input_kmers[0])
-        input_shape = (input_kmer_count, input_kmer_length)
-        input_seq = np.zeros(input_shape, dtype="int8")
+        if input_kmer_count > 0:
+            input_kmer_length = len(input_kmers[0])
+            input_shape = (input_kmer_count, input_kmer_length)
+            input_seq = np.zeros(input_shape, dtype="int8")
 
-        input_quality = np.array(quality_kmers)
+            for i in range(input_kmer_count):
+                kmer = input_kmers[i]
+                for j in range(input_kmer_length):
+                    encoding = ONE_HOT_ENCODING_IDX_MAP[kmer[j]]
+                    input_seq[i][j] = encoding
+        else:
+            input_seq = np.array([])
 
         output_kmer_count = len(output_kmers)
-        output_kmer_length = len(output_kmers[0])
-        full_output_kmer_length = (input_kmer_length + output_kmer_length) if fill_in_the_blanks else output_kmer_length
-        output_shape = (output_kmer_count, full_output_kmer_length)
-        output_seq = np.zeros(output_shape, dtype="int8")
-        shifted_output_seq = np.zeros(output_shape, dtype="int8")
 
-        for i in range(input_kmer_count):
-            kmer = input_kmers[i]
-            for j in range(input_kmer_length):
-                encoding = ONE_HOT_ENCODING_IDX_MAP[kmer[j]]
-                input_seq[i][j] = encoding
-                if fill_in_the_blanks:
-                    output_seq[i][j] = encoding
-                    shifted_output_seq[i][j+1] = encoding #TODO: assumes theres at least 1 output base
+        if output_kmer_count > 0:
+            output_kmer_length = len(output_kmers[0])
+            output_shape = (output_kmer_count, output_kmer_length)
+            output_seq = np.zeros(output_shape, dtype="int8")
+            shifted_output_seq = np.zeros(output_shape, dtype="int8")
 
-        for i in range(output_kmer_count):
-            kmer = output_kmers[i]
-            shifted_output_seq[i][0] = ONE_HOT_ENCODING_IDX_MAP["!"]
-            for j in range(output_kmer_length):
-                encoding = ONE_HOT_ENCODING_IDX_MAP[kmer[j]]
-                if fill_in_the_blanks:
-                    column = input_kmer_length + j
-                    output_seq[i][column] = encoding
-                    if column + 1 < full_output_kmer_length:
-                        shifted_output_seq[i][column + 1] = encoding
-                else:
+            for i in range(output_kmer_count):
+                kmer = output_kmers[i]
+                shifted_output_seq[i][0] = ONE_HOT_ENCODING_IDX_MAP["!"]
+                for j in range(output_kmer_length):
+                    encoding = ONE_HOT_ENCODING_IDX_MAP[kmer[j]]
                     output_seq[i][j] = encoding
-                    if j + 1 < full_output_kmer_length:
+                    if j + 1 < output_kmer_length:
                         shifted_output_seq[i][j + 1] = encoding
+        else:
+            output_seq = np.array([])
+            shifted_output_seq = np.array([])
+
+        input_quality = np.array(quality_kmers)
 
         return input_seq, np.array(input_quality), output_seq, shifted_output_seq

--- a/src/app/rnn/app_dummy.py
+++ b/src/app/rnn/app_dummy.py
@@ -35,7 +35,7 @@ def extract_read_matrix(paths, input_length, spacing, bases_to_predict, include_
     print("Stats took " + str(end_time - start_time) + "s")
 
     start_time = time.time()
-    input_seq, input_quality, output_seq, shifted_output_seq = encoder.encode_kmers(input_kmers, output_kmers, quality_vectors, fill_in_the_blanks=True)
+    input_seq, input_quality, output_seq, shifted_output_seq = encoder.encode_kmers(input_kmers, output_kmers, quality_vectors)
     end_time = time.time()
     print("Label Integer Encoding took " + str(end_time - start_time) + "s")
     return input_seq, input_quality, output_seq
@@ -66,7 +66,7 @@ def main():
     match_calculator = SequenceMatchCalculator()
 
     arguments = sys.argv[1:]
-    paths = arguments if len(arguments) > 0 else ['data/read_1_1000.fastq', 'data/read_2_1000.fastq']
+    paths = arguments if len(arguments) > 0 else ['../data/read_1_1000.fastq', '../data/read_2_1000.fastq']
     input_one_hot_cube, output_one_hot_cube = encode_reads(paths, input_length, spacing, bases_to_predict)
 
     output_decoder = OneHotMatrixDecoder(input_length + bases_to_predict)
@@ -89,9 +89,7 @@ def main():
     print("Decoding took " + str(end_time - start_time) + "s")
 
     start_time = time.time()
-    total_bases = input_length + bases_to_predict
-    start_idx = total_bases - bases_to_predict
-    matches = match_calculator.compare_sequences(decoded_predicted_output, decoded_actual_output, start_idx=start_idx, bases_to_check=bases_to_predict)
+    matches = match_calculator.compare_sequences(decoded_predicted_output, decoded_actual_output, bases_to_check=bases_to_predict)
 
     mean_match = np.mean(matches, axis=0)
     print("Mean Match = " + str(mean_match))

--- a/src/app/rnn/app_helper.py
+++ b/src/app/rnn/app_helper.py
@@ -17,7 +17,7 @@ def get_stats(inputs, outputs, verbose = False):
         print(str(freq_map.get_inputs_with_redundant_mappings()))
     return freq_map
 
-def extract_read_matrix(paths, input_length, spacing, bases_to_predict, include_reverse_complement, unique, fill_in_the_blanks, verbose=False):
+def extract_read_matrix(paths, input_length, spacing, bases_to_predict, include_reverse_complement, unique, verbose=False):
     importer = SequenceImporter()
     extractor = SlidingWindowExtractor(input_length, spacing, bases_to_predict)
     encoder = KmerLabelEncoder()
@@ -39,7 +39,7 @@ def extract_read_matrix(paths, input_length, spacing, bases_to_predict, include_
 
     start_time = time.time()
     input_seq, input_quality, output_seq, shifted_output_seq = \
-        encoder.encode_kmers(input_kmers, output_kmers, quality_vectors, fill_in_the_blanks=fill_in_the_blanks)
+        encoder.encode_kmers(input_kmers, output_kmers, quality_vectors)
     end_time = time.time()
     print("Label Integer Encoding took " + str(end_time - start_time) + "s")
     return input_seq, input_quality, output_seq, shifted_output_seq, input_stats_map

--- a/src/app/rnn/app_keras.py
+++ b/src/app/rnn/app_keras.py
@@ -16,12 +16,11 @@ def main():
     spacing = 0
     has_quality = False
     unique = False
-    fill_in_the_blanks = False
 
     arguments = sys.argv[1:]
     paths = arguments if len(arguments) > 0 else ['../data/read_1_300.fastq']
     input_seq, input_quality, output_seq, shifted_output_seq, input_stats_map = helper.extract_read_matrix(paths, input_length, spacing,
-                                                                                   bases_to_predict, include_reverse_complement, unique, fill_in_the_blanks)
+                                                                                   bases_to_predict, include_reverse_complement, unique)
 
     input_seq_train, input_seq_valid, input_quality_train, input_quality_valid, output_seq_train, output_seq_valid, shifted_output_train, shifted_output_valid = model_selection.train_test_split(
         input_seq, input_quality, output_seq, shifted_output_seq, test_size=0.15, random_state=123)

--- a/src/app/rnn/app_keras_load_weights.py
+++ b/src/app/rnn/app_keras_load_weights.py
@@ -16,12 +16,11 @@ def main():
     spacing = 0
     has_quality = False
     unique = False
-    fill_in_the_blanks = False
 
     arguments = sys.argv[1:]
     paths = arguments if len(arguments) > 0 else ['../data/ecoli_contigs/ecoli-0-400.fastq', '../data/ecoli_contigs/ecoli-600-1000.fastq']
     input_seq, input_quality, output_seq, shifted_output_seq, input_stats_map = helper.extract_read_matrix(paths, input_length, spacing,
-                                                                                   bases_to_predict, include_reverse_complement, unique, fill_in_the_blanks)
+                                                                                   bases_to_predict, include_reverse_complement, unique)
 
     input_seq_train, input_seq_valid, input_quality_train, input_quality_valid, output_seq_train, output_seq_valid, shifted_output_train, shifted_output_valid = model_selection.train_test_split(
         input_seq, input_quality, output_seq, shifted_output_seq, test_size=0.01, random_state=123)

--- a/src/app/rnn/app_keras_separate_datasets.py
+++ b/src/app/rnn/app_keras_separate_datasets.py
@@ -14,7 +14,6 @@ def main():
     spacing = 0
     has_quality = False
     unique = False
-    fill_in_the_blanks = False
 
     training_paths = ['../data/ecoli_contigs/ecoli-0-400.fastq', '../data/ecoli_contigs/ecoli-600-1000.fastq']
     input_seq_train, input_quality_train, output_seq_train, shifted_output_train, train_input_stats_map = helper.extract_read_matrix(training_paths,
@@ -22,7 +21,7 @@ def main():
                                                                                                     spacing,
                                                                                                     bases_to_predict,
                                                                                                     include_reverse_complement,
-                                                                                                    unique, fill_in_the_blanks)
+                                                                                                    unique)
 
     validation_paths = ['data/ecoli_contigs/ecoli-400-600.fastq']
     input_seq_valid, input_quality_valid, output_seq_valid, shifted_output_valid, valid_input_stats_map = helper.extract_read_matrix(validation_paths,
@@ -30,7 +29,7 @@ def main():
                                                                                                     spacing,
                                                                                                     bases_to_predict,
                                                                                                     include_reverse_complement,
-                                                                                                    unique, fill_in_the_blanks)
+                                                                                                    unique)
     print("Encoding training set")
     input_one_hot_cube_train, output_one_hot_cube_train, shifted_output_seq_cube_train = helper.encode_reads(input_length,
                                                                                                       bases_to_predict,

--- a/src/app/rnn/interactive_predictor.py
+++ b/src/app/rnn/interactive_predictor.py
@@ -26,7 +26,6 @@ def main():
     input_length = 26
     bases_to_predict = 1
     has_quality = False
-    fill_in_the_blanks = False
 
     label_encoder = KmerLabelEncoder()
     one_hot_encoder = OneHotMatrixEncoder(input_length)
@@ -43,8 +42,7 @@ def main():
             print(validation_result)
             continue
 
-        #TODO: the 2nd argument is a hack until we make encode_kmers robust to empty arrays, we ignore the output encodings so it doesn't matter
-        input_seq, input_quality, output_seq, shifted_output_seq = label_encoder.encode_kmers([kmer], ["A"], [], fill_in_the_blanks=fill_in_the_blanks)
+        input_seq, input_quality, output_seq, shifted_output_seq = label_encoder.encode_kmers([kmer], [], [])
         print("Encoded kmer: " + str(input_seq))
 
         input_one_hot_cube = one_hot_encoder.encode_sequences(input_seq)

--- a/src/predict/rnn/RandomPredictModel.py
+++ b/src/predict/rnn/RandomPredictModel.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import constants.EncodingConstants as CONSTANTS
-from constants.RnnEncodingConstants import INTEGER_ENCODING_MAP
 
 
 class RandomPredictModel:
@@ -9,24 +8,16 @@ class RandomPredictModel:
         self.k = k
         self.has_quality = has_quality
 
-
     def fit(self, X, Y):
         pass
 
     def predict(self, X):
         num_bases = len(CONSTANTS.BASES)
-        if self.has_quality:
-            X_copy = np.delete(X, len(INTEGER_ENCODING_MAP), axis=2)
-        for i in range(len(X_copy)):
-            matrix = X_copy[i]
+        dimensions = (len(X), self.k, num_bases)
+        predictions = np.zeros(dimensions)
+        for i in range(len(X)):
+            base_idx = np.random.randint(low=0, high=num_bases, size=self.k)
             for j in range(self.k):
-                offset = self.k - j
-                vector_idx = len(matrix) - offset
+                predictions[i][j][base_idx[j]] = 1
 
-                vector_prediction_idx = np.random.randint(num_bases)
-                vector_prediction = np.zeros(len(INTEGER_ENCODING_MAP))
-                vector_prediction[vector_prediction_idx+1] = 1
-
-                matrix[vector_idx] = vector_prediction
-
-        return X_copy
+        return predictions

--- a/test/test_kmer_label_encoder.py
+++ b/test/test_kmer_label_encoder.py
@@ -51,11 +51,8 @@ class TestKmerLabelEncoder(TestCase):
         np.testing.assert_array_equal(output_matrix, expected_output)
         np.testing.assert_array_equal(shifted_output_matrix, expected_shifted_output)
 
-    def test_encode_kmers_fill_in_the_blanks(self):
-        input_kmers = [
-            "AATT",
-            "ATTG"
-        ]
+    def test_encode_kmers_no_input(self):
+        input_kmers = []
         output_kmers = [
             "TC",
             "CG"
@@ -66,12 +63,48 @@ class TestKmerLabelEncoder(TestCase):
         ]
 
         input_matrix, input_quality_matrix, output_matrix, shifted_output_matrix = \
-            self.encoder.encode_kmers(input_kmers, output_kmers, input_quality, fill_in_the_blanks=True)
+            self.encoder.encode_kmers(input_kmers, output_kmers, input_quality)
+
+        self.assertEqual(input_matrix.shape, (0,))
+        self.assertEqual(input_quality_matrix.shape, (2, 4))
+        self.assertEqual(output_matrix.shape, (2, 2))
+        self.assertEqual(shifted_output_matrix.shape, (2, 2))
+        expected_input = np.array([])
+        expected_input_quality = np.array([
+            [28, 28, 28, 10],
+            [28, 28, 10, 28]
+        ])
+        expected_output = np.array([
+            [3, 1],
+            [1, 2]
+        ])
+        expected_shifted_output = np.array([
+            [4, 3],
+            [4, 1]
+        ])
+        np.testing.assert_array_equal(input_matrix, expected_input)
+        np.testing.assert_array_equal(input_quality_matrix, expected_input_quality)
+        np.testing.assert_array_equal(output_matrix, expected_output)
+        np.testing.assert_array_equal(shifted_output_matrix, expected_shifted_output)
+
+    def test_encode_kmers_no_output(self):
+        input_kmers = [
+            "AATT",
+            "ATTG"
+        ]
+        output_kmers = []
+        input_quality = [
+            [28, 28, 28, 10],
+            [28, 28, 10, 28]
+        ]
+
+        input_matrix, input_quality_matrix, output_matrix, shifted_output_matrix = \
+            self.encoder.encode_kmers(input_kmers, output_kmers, input_quality)
 
         self.assertEqual(input_matrix.shape, (2, 4))
         self.assertEqual(input_quality_matrix.shape, (2, 4))
-        self.assertEqual(output_matrix.shape, (2, 6))
-        self.assertEqual(shifted_output_matrix.shape, (2, 6))
+        self.assertEqual(output_matrix.shape, (0,))
+        self.assertEqual(shifted_output_matrix.shape, (0,))
         expected_input = np.array([
             [0, 0, 3, 3],
             [0, 3, 3, 2]
@@ -80,13 +113,43 @@ class TestKmerLabelEncoder(TestCase):
             [28, 28, 28, 10],
             [28, 28, 10, 28]
         ])
+        expected_output = np.array([])
+        expected_shifted_output = np.array([])
+        np.testing.assert_array_equal(input_matrix, expected_input)
+        np.testing.assert_array_equal(input_quality_matrix, expected_input_quality)
+        np.testing.assert_array_equal(output_matrix, expected_output)
+        np.testing.assert_array_equal(shifted_output_matrix, expected_shifted_output)
+
+    def test_encode_kmers_no_quality(self):
+        input_kmers = [
+            "AATT",
+            "ATTG"
+        ]
+        output_kmers = [
+            "TC",
+            "CG"
+        ]
+        input_quality = []
+
+        input_matrix, input_quality_matrix, output_matrix, shifted_output_matrix = \
+            self.encoder.encode_kmers(input_kmers, output_kmers, input_quality)
+
+        self.assertEqual(input_matrix.shape, (2, 4))
+        self.assertEqual(input_quality_matrix.shape, (0,))
+        self.assertEqual(output_matrix.shape, (2, 2))
+        self.assertEqual(shifted_output_matrix.shape, (2, 2))
+        expected_input = np.array([
+            [0, 0, 3, 3],
+            [0, 3, 3, 2]
+        ])
+        expected_input_quality = np.array([])
         expected_output = np.array([
-            [0, 0, 3, 3, 3, 1],
-            [0, 3, 3, 2, 1, 2]
+            [3, 1],
+            [1, 2]
         ])
         expected_shifted_output = np.array([
-            [4, 0, 0, 3, 3, 3],
-            [4, 0, 3, 3, 2, 1]
+            [4, 3],
+            [4, 1]
         ])
         np.testing.assert_array_equal(input_matrix, expected_input)
         np.testing.assert_array_equal(input_quality_matrix, expected_input_quality)


### PR DESCRIPTION
This logic doesn't seem to be needed anymore because we've framed our
problem to directly predict the next d bases, rather than trying
to output the first n bases ("known") and the next d bases (unknown)

We can also make our Label Encoder a bit more robust to empty inputs
now as a result since the logic isn't as interleaved between input
and output encoding