### PR TITLE
Implement a callback to take validation metric each epoch

### DIFF
--- a/src/app/new_rnn/app_keras.py
+++ b/src/app/new_rnn/app_keras.py
@@ -2,9 +2,31 @@ import sys
 sys.path.append('../../')
 
 import time
+import numpy as np
+import matplotlib.pyplot as plt
 
 from predict.new_rnn.SingleLSTMModel import SingleLSTMModel
 from preprocess.SequenceImporter import SequenceImporter
+
+def _plot_training_validation(epochs, validation_metrics, training_accuracy):
+    root_path = 'E:\\Users\\Documents\\School Year 18-19\\Term 1\\CPSC 449\\Sealer_NN\\src\\app\\new_rnn\\out\\'
+    #root_path = '/home/echen/Desktop/Projects/Sealer_NN/src/app/new_rnn/out/'
+
+    plt.figure()
+    plt.ylim(0, 1.1)
+    plt.xlabel('Epoch')
+    plt.ylabel('Training Accuracy')
+    plt.plot(epochs, training_accuracy)
+    plt.savefig('training_accuracy.png')
+    plt.clf()
+
+    plt.figure()
+    plt.ylim(0, 1.1)
+    plt.xlabel('Epoch')
+    plt.ylabel('Fraction Until Mismatch')
+    plt.plot(epochs, validation_metrics)
+    plt.savefig('percent_predicted_till_mismatch.png')
+    plt.clf()
 
 def main():
     include_reverse_complement = True
@@ -15,13 +37,21 @@ def main():
     importer = SequenceImporter()
     reads = importer.import_fastq(paths, include_reverse_complement)
 
-    model = SingleLSTMModel(min_seed_length=min_seed_length, stateful=False, batch_size=128, epochs=100, embedding_dim=25, latent_dim=100, with_gpu=True, log_samples=True)
+    path = '../data/ecoli_contigs/ecoli_contig_1000.fasta'
+    reference_sequence = importer.import_fasta([path])[0]
+
+    model = SingleLSTMModel(min_seed_length=min_seed_length, stateful=False, batch_size=128, epochs=100, embedding_dim=25, latent_dim=100, with_gpu=True, log_samples=True, reference_sequence=reference_sequence)
 
     start_time = time.time()
-    model.fit(reads)
+    history = model.fit(reads)
     model.save_weights('../weights/my_model_weights.h5')
     end_time = time.time()
     print("Fitting took " + str(end_time - start_time) + "s")
+
+    epochs = np.array(history.epoch)
+    validation_metrics = model.validation_history()[0]
+    training_accuracy = np.array(history.history['acc'])
+    _plot_training_validation(epochs, validation_metrics, training_accuracy)
 
 if __name__ == "__main__":
     main()

--- a/src/predict/new_rnn/ValidationMetric.py
+++ b/src/predict/new_rnn/ValidationMetric.py
@@ -1,0 +1,55 @@
+import numpy as np
+import keras as keras
+import constants.EncodingConstants as CONSTANTS
+from onehot.OneHotVector import OneHotVectorDecoder
+from preprocess.KmerLabelEncoder import KmerLabelEncoder
+
+class ValidationMetric(keras.callbacks.Callback):
+    def __init__(self, model, reference_seq, min_seed_length):
+        self.model = model
+        self.reference_seq = reference_seq
+        self.min_seed_length = min_seed_length
+        self.data = []
+        self.epochs = []
+
+    def on_epoch_end(self, epoch, logs=None):
+        validation_metric = self._percentage_until_mismatch()
+        self.data.append(validation_metric)
+        self.epochs.append(epoch)
+
+    def get_data(self):
+        return np.array(self.data), np.array(self.epochs)
+
+    def _percentage_until_mismatch(self):
+        label_encoder = KmerLabelEncoder()
+        prediction_length = 1
+        one_hot_decoder = OneHotVectorDecoder(prediction_length, encoding_constants=CONSTANTS)
+
+        sequence_length = len(self.reference_seq)
+        start_string = self.reference_seq[0:self.min_seed_length]
+        string_to_predict = self.reference_seq[self.min_seed_length:]
+
+        bases_to_predict = sequence_length - self.min_seed_length
+
+        remaining_length = bases_to_predict
+        length = self.min_seed_length
+
+        current_sequence = str(start_string)
+        while remaining_length > 0:
+            seed = current_sequence[0:length]
+            input_seq = label_encoder.encode_kmers([seed], [], with_shifted_output=False)[0]
+
+            prediction = self.model.predict(input_seq)
+            decoded_prediction = one_hot_decoder.decode_sequences(prediction)[0][0]
+            bases_predicted = bases_to_predict - remaining_length
+            expected_base = string_to_predict[bases_predicted]
+            if decoded_prediction != expected_base:
+                break;
+
+            current_sequence += decoded_prediction
+            remaining_length -= 1
+            length += 1
+        return bases_predicted/bases_to_predict
+
+
+


### PR DESCRIPTION
Our metric is what % of the reference sequence we can predict
before failing

One more optimization we might want to consider is seeing if we
can copy our model weights onto a stateful LSTM to see if that
speeds up validation prediction time as we're doing the stateless
implementation right now (which needs to predict on progressively
larger # of timesteps)