### PR TITLE
Implement more extensive training set

### DIFF
--- a/src/app/new_rnn/app_keras.py
+++ b/src/app/new_rnn/app_keras.py
@@ -51,15 +51,16 @@ def main():
 
     with_gpu=True
     log_samples=False
-    epochs = 1000
-    replicates = 2
+    log_training=False
+    epochs = 100
+    replicates = 1
 
     # (128, 1024, 1024) probably don't go further than this
     # doubling latent_dim seems to increase # parameters by ~3X
     # doubling embedding_dim seems to increase # parameters by ~1.5X
-    batch_sizes = [64, 128, 256]
-    embedding_dims = [32, 128, 512]
-    latent_dims = [32, 128, 512]
+    batch_sizes = [128]
+    embedding_dims = [128]
+    latent_dims = [64]
     for batch_size in batch_sizes:
         for embedding_dim in embedding_dims:
             for latent_dim in latent_dims:
@@ -68,7 +69,8 @@ def main():
                                             batch_size=batch_size,
                                             epochs=epochs, embedding_dim=embedding_dim, latent_dim=latent_dim,
                                             with_gpu=with_gpu,
-                                            log_samples=log_samples, reference_sequence=reference_sequence)
+                                            log_samples=log_samples, reference_sequence=reference_sequence,
+                                            log_training=log_training)
 
                     start_time = time.time()
                     history = model.fit(reads)
@@ -78,7 +80,10 @@ def main():
 
                     epoch_axis = np.array(history.epoch)
                     validation_metrics = model.validation_history()[0]
-                    training_accuracy = np.array(history.history['acc'])
+                    if log_training:
+                        training_accuracy = model.training_history()[0]
+                    else:
+                        training_accuracy = np.array(history.history['acc'])
                     directory_name = "BS_" + str(batch_size) + "_ED_" + str(embedding_dim) + "_LD_" + str(latent_dim) \
                                      + "_E_" + str(epochs) + "_R_" + str(i)
                     _plot_training_validation(epoch_axis, validation_metrics, training_accuracy, directory_name)

--- a/src/predict/new_rnn/TrainingMetric.py
+++ b/src/predict/new_rnn/TrainingMetric.py
@@ -1,0 +1,43 @@
+import numpy as np
+import keras as keras
+
+class TrainingMetric(keras.callbacks.Callback):
+    def __init__(self, model):
+        self.model = model
+        self.data = []
+        self.epochs = []
+        self.batches = []
+
+    def set_generator(self, generator):
+        self.generator = generator
+
+    def on_epoch_end(self, epoch, logs=None):
+        num_batches = len(self.batches)
+        accuracy_per_batch = np.zeros(num_batches)
+        batch_sizes = np.zeros(num_batches)
+        for i in range(num_batches):
+            batch_tuple = self.batches[i]
+            input = batch_tuple[0]
+            output = batch_tuple[1]
+            predictions = self.model.predict(input)
+            decoded_output = np.argmax(output, axis=1)
+            decoded_predictions = np.argmax(predictions, axis=1)
+            matches = np.equal(decoded_output, decoded_predictions)
+            accuracy = np.mean(matches)
+
+            accuracy_per_batch[i] = accuracy
+            batch_sizes[i] = len(input)
+
+        training_metric = np.sum(accuracy_per_batch*batch_sizes)/np.sum(batch_sizes)
+        self.data.append(training_metric)
+        self.epochs.append(epoch)
+        self.batches = []
+
+    def on_batch_end(self, batch, logs=None):
+        batch = self.generator._pop_earliest_batch()
+        self.batches.append(batch)
+
+    def get_data(self):
+        return np.array(self.data), np.array(self.epochs)
+
+


### PR DESCRIPTION
We now validate over all data points used in training for an
epoch at the end of the epoch with the final model weights at
that epoch. It should give a less biased metric of training error
than just the training error for the final batch (which we just
trained on). However, this adds a lot of overhead to the training
process. Might need to timestamp how long it takes to do the prediction
to see if it's because of how we're slicing lists or if it's
actually just the model prediction step.