### PR TITLE
Implement flank prediction to do random prediction

### DIFF
--- a/src/viz/SequenceRegenerationViz.py
+++ b/src/viz/SequenceRegenerationViz.py
@@ -111,7 +111,7 @@ class SequenceRegenerationViz:
         self._write_fasta(id + "_right_flank_reverse_complement_LD_" + str(latent_dim), rc_right_flank, file)
         file.close()
 
-    def compare_sequences(self, actual, predicted, seed_length, matches, offset=0, append=False):
+    def compare_sequences(self, actual, predicted, seed_length, matches, offset=0, append=False, id=None):
         static_padding = ""
 
         for i in range(offset):
@@ -131,7 +131,12 @@ class SequenceRegenerationViz:
                 break
 
         mode = "a" if append else "w+"
-        file = open(self.root_path + 'align.txt', mode)
+
+        if id is not None:
+            id_string = id + "_"
+        else:
+            id_string = ""
+        file = open(self.root_path + id_string + 'align.txt', mode)
 
         file.write("ACTUAL\n")
         file.write('\n')


### PR DESCRIPTION
In addition, we also do the old "predict and pray" approach where
we just keep greedily predicting more and more of the sequence until
we either finish or we spiral into errors

This will be done because we care about the total probability of the prediction

To do the total probability for the "correct sequence" prediction, we
can easily use the "teacher forcing" probability vector and just pick the
probability of the actual correct base rather than the largest probability
at a timestep... this is because each timestep came from a seed that
contained all of the correct prior bases

The random prediction is there as a control to see how bad a random
prediction would give us for probability